### PR TITLE
Change signature of the `PostRepository.AddPost` method

### DIFF
--- a/internal/mocks/mock_repositories.go
+++ b/internal/mocks/mock_repositories.go
@@ -36,7 +36,7 @@ func (m *MockPostRepository) EXPECT() *MockPostRepositoryMockRecorder {
 }
 
 // AddPost mocks base method.
-func (m *MockPostRepository) AddPost(arg0 *types.Post, arg1 *repository.User) (*repository.Post, error) {
+func (m *MockPostRepository) AddPost(arg0 *types.Post, arg1 uint) (*repository.Post, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddPost", arg0, arg1)
 	ret0, _ := ret[0].(*repository.Post)

--- a/internal/repository/post.go
+++ b/internal/repository/post.go
@@ -25,7 +25,7 @@ type Post struct {
 
 // PostRepository interface defining post-related database operations.
 type PostRepository interface {
-	AddPost(post *types.Post, author *User) (*Post, error)
+	AddPost(post *types.Post, authorID uint) (*Post, error)
 	GetPost(urlHandle string) (*Post, error)
 	GetPosts() ([]Post, error)
 }
@@ -54,17 +54,17 @@ func initPostModel(logger *zap.SugaredLogger, repository Repository) {
 }
 
 // AddPost adds a new post with the provided fields to the database.
-// The second User parameter holds information about the author.
-func (p postRepository) AddPost(post *types.Post, author *User) (*Post, error) {
+// The second parameter holds information about the author.
+func (p postRepository) AddPost(post *types.Post, authorID uint) (*Post, error) {
 	log := p.logger
 	repo := p.repository
 
 	newPost := Post{
 		URLHandle: post.URLHandle,
-		Author:    *author,
 		Title:     post.Title,
 		Summary:   post.Summary,
 		Body:      post.Body,
+		AuthorID:  authorID,
 	}
 
 	if result := repo.Create(&newPost); result.Error == nil {

--- a/internal/services/post.go
+++ b/internal/services/post.go
@@ -38,7 +38,7 @@ func (p postService) AddPost(newPost *types.Post) (types.Post, error) {
 
 	log.Infof("adding new post %v with author %s", newPost, newPost.Author)
 
-	post, err := postRepository.AddPost(newPost, author)
+	post, err := postRepository.AddPost(newPost, author.ID)
 	return mapPost(post), err
 }
 

--- a/internal/services/post_test.go
+++ b/internal/services/post_test.go
@@ -68,7 +68,7 @@ func TestPostService_AddPost(t *testing.T) {
 	}
 
 	c.mostUserRepository.EXPECT().GetUser(userModel.UserName).Return(&userModel, nil)
-	c.mostPostRepository.EXPECT().AddPost(&newPost, &userModel).Return(&postModel, nil)
+	c.mostPostRepository.EXPECT().AddPost(&newPost, userModel.ID).Return(&postModel, nil)
 
 	p, err := c.sut.AddPost(&newPost)
 
@@ -132,7 +132,7 @@ func TestPostService_Duplicate_Post(t *testing.T) {
 	expectedError := errortypes.DuplicateElementError{Key: postModel.URLHandle}
 
 	c.mostUserRepository.EXPECT().GetUser(userModel.UserName).Return(&userModel, nil)
-	c.mostPostRepository.EXPECT().AddPost(&newPost, &userModel).Return(nil, expectedError)
+	c.mostPostRepository.EXPECT().AddPost(&newPost, userModel.ID).Return(nil, expectedError)
 
 	p, err := c.sut.AddPost(&newPost)
 


### PR DESCRIPTION
To keep logic in the `UserRepository` and `PostRepository` independent, the parameter of the `AddPost` method has been changed to the `uint` type database ID of the author instead of the `*repository.User` pointer. 

Additionally, this way we save an unnecessary `INSERT INTO users...` call.